### PR TITLE
Move Babel | Webpack into devDependencies (package.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@babel/core": "^7.1.2",
     "@babel/preset-env": "^7.1.0",
-    "axios": "^0.18.0",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -28,16 +28,6 @@
     ]
   },
   "dependencies": {
-    "@babel/core": "^7.1.2",
-    "@babel/preset-env": "^7.1.0",
-    "axios": "^0.18.0",
-    "babel-core": "^6.26.3",
-    "babel-loader": "^7.1.5",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-3": "^6.24.1",
-    "body-parser": "^1.18.3",
     "express": "^4.16.3",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
@@ -49,13 +39,23 @@
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "three": "^0.98.0",
-    "three.ar.js": "^0.1.8",
-    "webpack": "^4.17.2",
-    "webpack-cli": "^3.1.0"
+    "three.ar.js": "^0.1.8"
   },
   "devDependencies": {
+    "@babel/core": "^7.1.2",
+    "@babel/preset-env": "^7.1.0",
+    "axios": "^0.18.0",
+    "babel-core": "^6.26.3",
+    "babel-loader": "^7.1.5",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-3": "^6.24.1",
+    "body-parser": "^1.18.3",
     "chai": "^4.2.0",
     "mocha": "^5.2.0",
-    "supertest": "^3.3.0"
+    "supertest": "^3.3.0",
+    "webpack": "^4.17.2",
+    "webpack-cli": "^3.1.0"
   }
 }


### PR DESCRIPTION
Moved babel and webpack into devDependencies (package.json)

Please run npm install before running app.